### PR TITLE
feat: format options for infusing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { SFCDescriptor } from 'vue-template-compiler'
-import { SFCFileInfo } from '../types'
+import { SFCFileInfo, FormatOptions } from '../types'
 import { VueTemplateCompiler } from '@vue/component-compiler-utils/dist/types'
 
 import { parse } from '@vue/component-compiler-utils'
@@ -77,17 +77,30 @@ export function parseContent (content: string, lang: string): any {
   }
 }
 
-export function stringifyContent (content: any, lang: string): string {
+export function stringifyContent (content: any, lang: string, options?: FormatOptions): string {
+  const indent = options?.intend || 2
+  const eol = options?.eol || '\n'
+
+  let result = ''
   switch (lang) {
     case 'yaml':
     case 'yml':
-      return yaml.safeDump(content, { indent: 2 })
+      result = yaml.safeDump(content, { indent })
+      break
     case 'json5':
-      return JSON5.stringify(content, null, 2)
+      result = JSON5.stringify(content, null, indent)
+      break
     case 'json':
     default:
-      return JSON.stringify(content, null, 2)
+      result = JSON.stringify(content, null, indent)
+      break
   }
+
+  if (!result.endsWith(eol)) {
+    result += eol
+  }
+
+  return result
 }
 
 export function readSFC (target: string): SFCFileInfo[] {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,7 +79,7 @@ export function parseContent (content: string, lang: string): any {
 
 export function stringifyContent (content: any, lang: string, options?: FormatOptions): string {
   const indent = options?.intend || 2
-  const eol = options?.eol || '\n'
+  const eof = options?.eof || '\n'
 
   let result = ''
   switch (lang) {
@@ -96,8 +96,8 @@ export function stringifyContent (content: any, lang: string, options?: FormatOp
       break
   }
 
-  if (!result.endsWith(eol)) {
-    result += eol
+  if (!result.endsWith(eof)) {
+    result += eof
   }
 
   return result

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -82,7 +82,7 @@ export type MetaLocaleMessage = {
 }
 export type FormatOptions = {
   intend?: number,
-  eol?: string
+  eof?: string
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,8 +26,8 @@ import { SFCDescriptor } from 'vue-template-compiler'
  */
 
 export type Locale = string
-export type LocaleMessage = 
-  | string 
+export type LocaleMessage =
+  | string
   | { [property: string]: LocaleMessage }
   | LocaleMessage[]
 export type LocaleMessages = Record<Locale, LocaleMessage>
@@ -79,6 +79,10 @@ export type SFCI18nBlock = {
 export type MetaLocaleMessage = {
   target: string,
   components: Record<string, SFCI18nBlock[]>
+}
+export type FormatOptions = {
+  intend?: number,
+  eol?: string
 }
 
 /**
@@ -153,7 +157,7 @@ export interface SFCFileInfo {
  */
 
 declare function squeeze (basePath: string, files: SFCFileInfo[]): MetaLocaleMessage
-declare function infuse (basePath: string, sources: SFCFileInfo[], meta: MetaLocaleMessage): SFCFileInfo[]
+declare function infuse (basePath: string, sources: SFCFileInfo[], meta: MetaLocaleMessage, options?: FormatOptions): SFCFileInfo[]
 
 // extend for vue-i18n-locale-message
 declare module 'vue-template-compiler' {


### PR DESCRIPTION
This PR introduces a new parameter for infusing. Allowing passing format options to the infuser.

The option type:
```ts
export type FormatOptions = {
  intend?: number, // default: 2
  eof?: string // default: "\n"
}
```

----------

Currently the infuser will output like this
```html
<i18n locale="en" lang="json5">
{
  id: 'User ID',
  password: 'Password'
}</i18n>
```

In this PR, the output will be: (by passing `eof` option, you would able to use Windows CRLF eol or disable eof totally)
```html
<i18n locale="en" lang="json5">
{
  id: 'User ID',
  password: 'Password'
}
</i18n>
```